### PR TITLE
Adding ability to supply defrec with a docstring

### DIFF
--- a/src/xodarap/core.clj
+++ b/src/xodarap/core.clj
@@ -10,28 +10,53 @@
         (for [name names]
           (symbol (str rec-prefix name)))))
 
+(defn- add-meta
+  "merge any key values from opts into the meta data of
+  the desired var."
+  [name opts]
+  (with-meta name (merge (meta name) opts)))
+
+(defn- parse-params
+  "Used to handle determining which parameters are
+  meant to be docstring or argv. Returns a map of all
+  arguments that defrec uses."
+  [args]
+  (let [second-arg (second args)
+        docstring (when (string? second-arg)
+                    second-arg)]
+    {:name (first args)
+     :doc (str docstring)
+     :argv (if (vector? second-arg)
+             second-arg
+             (nth args 2))
+     :body (drop (if docstring 3 2) args)}))
+
 (defmacro defrec
   "Like `defn`, but defines a recursive fn that
   doesn't blow the stack iff recursive calls are
   wrapped in `rec`."
-  [name argv & body]
-  (let [internal-name (symbol (str rec-prefix name))]
-    `(do (defn ~internal-name ~argv
-           (go
-             ~@body))
-         (defn ~name ~argv
-           (<!! (~internal-name ~@argv))))))
+  [& args]
+  (let [{:keys [name doc argv body]} (parse-params args)
+        internal-name (symbol (str rec-prefix name))
+        meta-data {:doc doc}]
+    `(do
+       (defn ~(add-meta internal-name meta-data)
+         ~argv
+         (go ~@body))
+       (defn ~(add-meta name meta-data)
+         ~argv
+         (<!! (~internal-name ~@argv))))))
 
 (letfn [(internal-sym-name [sym]
           (let [ns (namespace sym)
                 n (name sym)]
             (symbol
-             (if ns
-               (str ns "/" rec-prefix n)
-               (str rec-prefix n)))))]
+              (if ns
+                (str ns "/" rec-prefix n)
+                (str rec-prefix n)))))]
   (defmacro rec
     "Converts a stack-blowing recursive call into a safe one.
-  Use with `defrec`."
+    Use with `defrec`."
     [expr]
     (let [[op & args] expr]
       `(<! ~(cons (internal-sym-name op) args)))))

--- a/test/xodarap/core_test.clj
+++ b/test/xodarap/core_test.clj
@@ -1,6 +1,6 @@
 (ns xodarap.core-test
   (:require [clojure.test :refer :all]
-            [xodarap.core :refer :all]))
+            [xodarap.core :as core :refer :all]))
 
 ;; Simple Recursion
 ;; ================
@@ -12,7 +12,6 @@
 (deftest simple-recursion-test
   (is (== (apply *' (range 1 10001))
           (fact 10000))))
-
 
 ;; Mutual Recursion
 ;; ================
@@ -31,3 +30,40 @@
 (deftest mutual-recursion-test
   (is (ODD? 10001))
   (is (EVEN? 10000)))
+
+;; Docstring Support
+;; =================
+
+(defrec f-no-docstring
+  [x]
+  (if (zero? x)
+    true
+    (rec (f-no-docstring (dec x)))))
+
+(defrec f-docstring
+  "This is my docstring!"
+  [x]
+  (if (zero? x)
+    true
+    (rec (f-docstring (dec x)))))
+
+(deftest docstring-test
+  (is (= true
+         (f-docstring 1000)
+         (f-no-docstring 1000)))
+  (is (= "This is my docstring!"
+         (:doc (meta #'f-docstring))))
+  (is (= ""
+         (:doc (meta #'f-no-docstring)))))
+
+(deftest parse-params-test
+  (is (= {:name 'foo
+          :doc "Docstring"
+          :argv ['a 'b]
+          :body (list + 'a 'b)}
+         (#'core/parse-params ['foo "Docstring" ['a 'b] + 'a 'b])))
+  (is (= {:name 'foo
+          :doc ""
+          :argv ['a 'b]
+          :body (list + 'a 'b)}
+         (#'core/parse-params ['foo ['a 'b] + 'a 'b]))))


### PR DESCRIPTION
Addresses https://github.com/divs1210/xodarap/issues/1

`defrec` will now accept a docstring, which is added to the function metadata - works the same way as `defn`. 

```
;; with docstring
(defrec foo 
  "docstring"
  [x]
  (inc x))

;; without docstring
(defrec foo
  [x]
  (inx x))  
```