### PR TITLE
Add support for defining a private recursive function with defrec-

### DIFF
--- a/src/xodarap/core.clj
+++ b/src/xodarap/core.clj
@@ -11,14 +11,12 @@
         (for [name names]
           (symbol (str rec-prefix name)))))
 
-(defmacro defrec
-  "Like `defn`, but defines a recursive fn that
-  doesn't blow the stack iff recursive calls are
-  wrapped in `rec`."
-  [& args]
+(defn- defrec*
+  [args & [private?]]
   (let [{:keys [name doc argv body]} (parse-params args)
         internal-name (symbol (str rec-prefix name))
-        meta-data {:doc doc}]
+        meta-data {:doc doc
+                   :private (boolean private?)}]
     `(do
        (defn ~(add-meta internal-name meta-data)
          ~argv
@@ -26,6 +24,20 @@
        (defn ~(add-meta name meta-data)
          ~argv
          (<!! (~internal-name ~@argv))))))
+
+(defmacro defrec
+  "Like `defn`, but defines a recursive fn that
+  doesn't blow the stack iff recursive calls are
+  wrapped in `rec`."
+  [& args]
+  (defrec* args))
+
+(defmacro defrec-
+  "Like `defn`, but defines a private recursive fn
+  that doesn't blow the stack iff recursive calls
+  are wrapped in `rec`."
+  [& args]
+  (defrec* args true))
 
 (letfn [(internal-sym-name [sym]
           (let [ns (namespace sym)

--- a/test/xodarap/core_test.clj
+++ b/test/xodarap/core_test.clj
@@ -1,6 +1,7 @@
 (ns xodarap.core-test
   (:require [clojure.test :refer :all]
-            [xodarap.core :refer :all]))
+            [xodarap.core :refer :all]
+            [xodarap.private-fn :as private-fn]))
 
 ;; Simple Recursion
 ;; ================
@@ -56,3 +57,15 @@
          (:doc (meta #'f-docstring))))
   (is (= ""
          (:doc (meta #'f-no-docstring)))))
+
+;; Private function definition
+;; ===========================
+
+(deftest private-defspec-test
+  (is (= 120
+         (private-fn/public-recursive 5)
+         (#'private-fn/private-recursive 5))
+      "Test that private fn acts the same as the public version.")
+  (testing "Check the value of private in function meta data"
+    (is (false? (-> private-fn/public-recursive var meta :private)))
+    (is (true? (-> private-fn/private-recursive var meta :private)))))

--- a/test/xodarap/core_test.clj
+++ b/test/xodarap/core_test.clj
@@ -58,9 +58,9 @@
   (is (= ""
          (:doc (meta #'f-no-docstring)))))
 
+
 ;; Private function definition
 ;; ===========================
-
 (deftest private-defspec-test
   (is (= 120
          (private-fn/public-recursive 5)

--- a/test/xodarap/private_fn.clj
+++ b/test/xodarap/private_fn.clj
@@ -1,0 +1,14 @@
+(ns xodarap.private-fn
+  (:require [xodarap.core :refer :all]))
+
+(defrec public-recursive
+  [n]
+  (if (zero? n)
+    1
+    (* n (rec (public-recursive (dec n))))))
+
+(defrec- private-recursive
+  [n]
+  (if (zero? n)
+    1
+    (* n (rec (private-recursive (dec n))))))


### PR DESCRIPTION
Addresses https://github.com/divs1210/xodarap/issues/2

```
Ran 5 tests containing 11 assertions.
0 failures, 0 errors.
```

Adds support for `defrec-`, which acts the same way as `defn-` in terms of privacy. 